### PR TITLE
Normalize backend error finish reasons for frontend parsing

### DIFF
--- a/components/src/dynamo/common/utils/engine_response.py
+++ b/components/src/dynamo/common/utils/engine_response.py
@@ -4,9 +4,10 @@
 """Utilities for engine response processing."""
 
 import logging
+from typing import Any
 
 
-def normalize_finish_reason(finish_reason: str) -> str:
+def normalize_finish_reason(finish_reason: str) -> Any:
     """
     Normalize engine finish reasons to Dynamo-compatible values.
 
@@ -18,4 +19,13 @@ def normalize_finish_reason(finish_reason: str) -> str:
     if finish_reason and finish_reason.startswith("abort"):
         logging.debug(f"Normalizing finish reason: {finish_reason} to cancelled")
         return "cancelled"
+    # Rust serializes FinishReason::Error(String) as {"error": "..."}.
+    # Returning the bare string "error" causes deserialization to fail on the
+    # frontend when backend workers report a generation error.
+    if finish_reason == "error":
+        logging.debug("Normalizing bare error finish reason to structured error")
+        return {"error": "backend error"}
+    if finish_reason and finish_reason.startswith("error:"):
+        logging.debug("Normalizing string error finish reason to structured error")
+        return {"error": finish_reason.split(":", 1)[1].strip() or "backend error"}
     return finish_reason


### PR DESCRIPTION
## Summary
- address #4
- apply the isolated fix from validation work
- keep the change limited to the issue-specific behavior

## Testing
- not run in this PR worktree
- extracted from the validated local change set