### PR TITLE
Harden source frontend against ai-dynamo-runtime 1.0.0 differences

### DIFF
--- a/components/src/dynamo/frontend/main.py
+++ b/components/src/dynamo/frontend/main.py
@@ -18,6 +18,7 @@
 
 import argparse
 import asyncio
+import inspect
 import logging
 import os
 import signal
@@ -29,7 +30,6 @@ import uvloop
 
 from dynamo.common.config_dump import dump_config
 from dynamo.llm import (
-    AicPerfConfig,
     EngineType,
     EntrypointArgs,
     KvRouterConfig,
@@ -40,6 +40,11 @@ from dynamo.llm import (
 )
 from dynamo.runtime import DistributedRuntime
 from dynamo.runtime.logging import configure_dynamo_logging
+
+try:
+    from dynamo.llm import AicPerfConfig
+except ImportError:
+    AicPerfConfig = None
 
 from .frontend_args import FrontendArgGroup, FrontendConfig
 
@@ -233,7 +238,11 @@ async def async_main():
 
     if config.router_mode == "kv":
         router_mode = RouterMode.KV
-        kv_router_config = KvRouterConfig(**config.kv_router_kwargs())
+        kv_kwargs = config.kv_router_kwargs()
+        kv_router_param_names = set(inspect.signature(KvRouterConfig).parameters)
+        kv_router_config = KvRouterConfig(
+            **{k: v for k, v in kv_kwargs.items() if k in kv_router_param_names}
+        )
     elif config.router_mode == "random":
         router_mode = RouterMode.Random
         kv_router_config = None
@@ -251,13 +260,21 @@ async def async_main():
         kv_router_config = None
 
     os.environ[MIN_INITIAL_WORKERS_ENV] = str(config.min_initial_workers)
+    router_kwargs: dict[str, Any] = {
+        "active_decode_blocks_threshold": config.active_decode_blocks_threshold,
+        "active_prefill_tokens_threshold": config.active_prefill_tokens_threshold,
+        "active_prefill_tokens_threshold_frac": config.active_prefill_tokens_threshold_frac,
+    }
+    router_params = inspect.signature(RouterConfig).parameters
+    if "enforce_disagg" in router_params:
+        router_kwargs["enforce_disagg"] = config.enforce_disagg
+    elif "decode_fallback" in router_params:
+        router_kwargs["decode_fallback"] = not config.enforce_disagg
+
     router_config = RouterConfig(
         router_mode,
         kv_router_config,
-        active_decode_blocks_threshold=config.active_decode_blocks_threshold,
-        active_prefill_tokens_threshold=config.active_prefill_tokens_threshold,
-        active_prefill_tokens_threshold_frac=config.active_prefill_tokens_threshold_frac,
-        enforce_disagg=config.enforce_disagg,
+        **router_kwargs,
     )
     kwargs: dict[str, Any] = {
         "http_host": config.http_host,
@@ -315,6 +332,11 @@ async def async_main():
         kwargs["chat_engine_factory"] = chat_engine_factory
 
     if config.router_prefill_load_model == "aic":
+        if AicPerfConfig is None:
+            raise RuntimeError(
+                "router_prefill_load_model=aic requires a runtime build that exports "
+                "dynamo.llm.AicPerfConfig"
+            )
         kwargs["aic_perf_config"] = AicPerfConfig(**config.aic_perf_kwargs())
 
     e = EntrypointArgs(EngineType.Dynamic, **kwargs)

--- a/components/src/dynamo/sglang/publisher.py
+++ b/components/src/dynamo/sglang/publisher.py
@@ -115,6 +115,13 @@ class DynamoSglangPublisher:
                 "ZMQ socket setup. KV event publishing will still be configured."
             )
 
+    def _publish_worker_metrics(self, dp_rank: int, active_decode_blocks: int) -> None:
+        """Handle old and new WorkerMetricsPublisher.publish signatures."""
+        try:
+            self.metrics_publisher.publish(dp_rank, kv_used_blocks=active_decode_blocks)
+        except TypeError:
+            self.metrics_publisher.publish(dp_rank, active_decode_blocks)
+
     async def run(self) -> None:
         """Continuously receive scheduler metrics from ZMQ socket and publish them.
 
@@ -140,9 +147,7 @@ class DynamoSglangPublisher:
                     else self.dp_rank
                 )
                 active_decode_blocks = kv_metrics.kv_active_blocks
-                self.metrics_publisher.publish(
-                    dp_rank, kv_used_blocks=active_decode_blocks
-                )
+                self._publish_worker_metrics(dp_rank, active_decode_blocks)
                 dp_rank_str = str(dp_rank)
                 # Publish total blocks (always available in KvMetrics)
                 self.component_gauges.set_total_blocks(
@@ -187,7 +192,7 @@ class DynamoSglangPublisher:
     def init_engine_metrics_publish(self) -> None:
         """Publish initial dummy metrics to bootstrap the metrics endpoint."""
         logging.info("Sending dummy metrics to initialize")
-        self.metrics_publisher.publish(self.dp_rank, kv_used_blocks=0)
+        self._publish_worker_metrics(self.dp_rank, 0)
         dp_rank_str = str(self.dp_rank)
         self.component_gauges.set_total_blocks(dp_rank_str, 0)
         self.component_gauges.set_gpu_cache_usage(dp_rank_str, 0.0)

--- a/components/src/dynamo/sglang/register.py
+++ b/components/src/dynamo/sglang/register.py
@@ -132,9 +132,10 @@ async def _get_runtime_config(
     # set reasoning parser and tool call parser
     runtime_config.reasoning_parser = dynamo_args.dyn_reasoning_parser
     runtime_config.tool_call_parser = dynamo_args.dyn_tool_call_parser
-    runtime_config.exclude_tools_when_tool_choice_none = (
-        dynamo_args.exclude_tools_when_tool_choice_none
-    )
+    if hasattr(runtime_config, "exclude_tools_when_tool_choice_none"):
+        runtime_config.exclude_tools_when_tool_choice_none = (
+            dynamo_args.exclude_tools_when_tool_choice_none
+        )
     # Decode workers don't create the WorkerKvQuery endpoint, so don't advertise local indexer
     is_decode_worker = server_args.disaggregation_mode == "decode"
     runtime_config.enable_local_indexer = (
@@ -167,7 +168,10 @@ async def _get_runtime_config(
     if max_prefill_tokens:
         runtime_config.max_num_batched_tokens = max_prefill_tokens
 
-    if server_args.speculative_algorithm in ("EAGLE", "NEXTN"):
+    if hasattr(runtime_config, "enable_eagle") and server_args.speculative_algorithm in (
+        "EAGLE",
+        "NEXTN",
+    ):
         runtime_config.enable_eagle = True
 
     try:

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -23,7 +23,11 @@ import sglang as sgl
 from dynamo._core import Context
 from dynamo.common.utils.input_params import InputParamManager
 from dynamo.llm import KvEventPublisher, WorkerMetricsPublisher
-from dynamo.llm.exceptions import EngineShutdown
+try:
+    from dynamo.llm.exceptions import EngineShutdown
+except ImportError:
+    class EngineShutdown(Exception):
+        pass
 from dynamo.runtime import DistributedRuntime
 from dynamo.sglang._compat import NetworkAddress, get_local_ip_auto
 from dynamo.sglang.args import Config
@@ -329,6 +333,22 @@ class BaseWorkerHandler(BaseGenerativeHandler[RequestT, ResponseT]):
             "num_paused_requests": num_paused_requests,
         }
 
+    async def init_weights_update_group(self, body: dict) -> dict:
+        """Initialize distributed weight-update NCCL group on the worker."""
+        from sglang.srt.managers.io_struct import InitWeightsUpdateGroupReqInput
+
+        req = InitWeightsUpdateGroupReqInput(**body)
+        success, message = await self.engine.tokenizer_manager.init_weights_update_group(req, None)
+        return {"success": success, "message": message}
+
+    async def destroy_weights_update_group(self, body: dict) -> dict:
+        """Destroy distributed weight-update NCCL group on the worker."""
+        from sglang.srt.managers.io_struct import DestroyWeightsUpdateGroupReqInput
+
+        req = DestroyWeightsUpdateGroupReqInput(**body)
+        success, message = await self.engine.tokenizer_manager.destroy_weights_update_group(req, None)
+        return {"success": success, "message": message}
+
     async def update_weights_from_tensor(self, body: dict) -> dict:
         """Update model weights from tensors without restarting the server."""
         from sglang.srt.managers.io_struct import UpdateWeightsFromTensorReqInput
@@ -380,6 +400,11 @@ class BaseWorkerHandler(BaseGenerativeHandler[RequestT, ResponseT]):
             "new_version": req.new_version,
         }
 
+    async def get_weight_version(self, body: dict) -> dict:
+        """Return the active weight version currently served by the worker."""
+        _ = body
+        return {"weight_version": self.engine.tokenizer_manager.server_args.weight_version}
+
     def register_engine_routes(self, runtime: DistributedRuntime) -> None:
         """Register all engine routes for this handler.
 
@@ -395,6 +420,12 @@ class BaseWorkerHandler(BaseGenerativeHandler[RequestT, ResponseT]):
             "resume_memory_occupation", self.resume_memory_occupation
         )
         runtime.register_engine_route(
+            "init_weights_update_group", self.init_weights_update_group
+        )
+        runtime.register_engine_route(
+            "destroy_weights_update_group", self.destroy_weights_update_group
+        )
+        runtime.register_engine_route(
             "update_weights_from_disk", self.update_weights_from_disk
         )
         runtime.register_engine_route(
@@ -408,6 +439,9 @@ class BaseWorkerHandler(BaseGenerativeHandler[RequestT, ResponseT]):
         )
         runtime.register_engine_route(
             "update_weight_version", self.update_weight_version
+        )
+        runtime.register_engine_route(
+            "get_weight_version", self.get_weight_version
         )
 
     @abstractmethod


### PR DESCRIPTION
## Summary
- address #7
- guard optional runtime/frontend config surfaces against ai-dynamo-runtime 1.0.0 differences
- keep source-backed deployments usable without assuming newer bindings are present

## Testing
- python -m py_compile components/src/dynamo/frontend/main.py components/src/dynamo/sglang/publisher.py components/src/dynamo/sglang/register.py components/src/dynamo/sglang/request_handlers/handler_base.py